### PR TITLE
Minor corrections to WCS enpoints in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,8 +225,8 @@ of the following addresses into your WCS client:
   | Bathymetry       | Data Products                             | https://ows.emodnet-bathymetry.eu/wcs?SERVICE=WCS&REQUEST=GetCapabilities&VERSION=2.0.1                             |
   | Biology          | Data Products                             | https://geo.vliz.be/geoserver/Emodnetbio/wcs?SERVICE=WCS&REQUEST=GetCapabilities&VERSION=2.0.1                      |
   | Human Activities | Data and Data Products                    | https://ows.emodnet-humanactivities.eu/wcs?SERVICE=WCS&REQUEST=GetCapabilities&VERSION=2.0.1                        |
-  | Physics          | Platforms                                 | http://geoserver.emodnet-physics.eu/geoserver/wcs?SERVICE=WCS&REQUEST=GetCapabilities&VERSION=2.0.1                 |
-  | Seabed Habitats  | Individual habitat map and model datasets | https//ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wcs?SERVICE=WCS&REQUEST=GetCapabilities&VERSION=2.0.1 |
+  | Physics          | Platforms                                 | https://geoserver.emodnet-physics.eu/geoserver/wcs?SERVICE=WCS&REQUEST=GetCapabilities&VERSION=2.0.1                 |
+  | Seabed Habitats  | Individual habitat map and model datasets | https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wcs?SERVICE=WCS&REQUEST=GetCapabilities&VERSION=2.0.1 |
   --------------------------------------------------------------------- ---------------------------------------------------------------------
 
 ##### WCS GetCapabilities


### PR DESCRIPTION
Correct typo in WCS seabed habitat endpoint url and set physics endpoint to use `https`